### PR TITLE
Suggestions to Rust code

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ fn await_foo(py: Python, foo: PyObject) -> PyResult<()> {
 
             // if it errors we know we're done.
             Err(e) => {
-                if let Ok(stop_iteration) = e.pvalue(py).extract::<PyStopIteration>() {
+                if let Ok(stop_iteration) = e.pvalue(py).downcast::<PyStopIteration>() {
                     let returned_value = stop_iteration.getattr("value")?;
                     
                     // Let's display that result of ours
@@ -212,5 +212,4 @@ fn await_from_rust(_py: Python, m: &PyModule) -> PyResult<()> {
     Ok(())
 }
 ```
-
 


### PR DESCRIPTION
Thanks for writing these notes, cool to see someone using PyO3 for async work!

I've been meaning to investigate this for a while (https://github.com/PyO3/pyo3/issues/701) but always so many great things to improve with PyO3 😄 

Regarding to your comment of Rust experiencing a slowdown on average compared to Python for async stuff, I'm sure we can improve that!

The `.call_method0` calls are in general quite inefficient (although are equivalent to the python code you wrote, so maybe it's fair to keep them). So I replaced `.call_method0("__iter__")` with `.iter()` which uses the underlying C-API.

Similarly it looks like there's a C-API which does something along the lines of `__await__` in https://github.com/python/cpython/blob/master/Include/genobject.h#L67 - we don't currently have an ffi definition for it in PyO3, but could be worth experimenting with.

Also for the `StopIteration` exception I think there's a nicer way you can do it accessing the object directly rather than casting to a `String`. The code I wrote also solves the problem of how to handle other exceptions to `StopIteration`. I have to confess I didn't actually try running that code so you may want to double-check it 🙈 
